### PR TITLE
nixos/virtualisation: add option for explicitly named network interfaces

### DIFF
--- a/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
+++ b/nixos/doc/manual/from_md/release-notes/rl-2211.section.xml
@@ -315,6 +315,15 @@
           release it may be removed.
         </para>
       </listitem>
+      <listitem>
+        <para>
+          A new option was added to the virtualisation module that
+          enables specifying explicitly named network interfaces in QEMU
+          VMs. The existing <literal>virtualisation.vlans</literal> is
+          still supported for cases where the name of the network
+          interface is irrelevant.
+        </para>
+      </listitem>
     </itemizedlist>
   </section>
 </section>

--- a/nixos/doc/manual/release-notes/rl-2211.section.md
+++ b/nixos/doc/manual/release-notes/rl-2211.section.md
@@ -114,6 +114,8 @@ Use `configure.packages` instead.
 
 - memtest86+ was updated from 5.00-coreboot-002 to 6.00-beta2. It is now the upstream version from https://www.memtest.org/, as coreboot's fork is no longer available.
 
+- A new option was added to the virtualisation module that enables specifying explicitly named network interfaces in QEMU VMs. The existing `virtualisation.vlans` is still supported for cases where the name of the network interface is irrelevant.
+
 - There is a new module for the `thunar` program (the Xfce file manager), which depends on the `xfconf` dbus service, and also has a dbus service and a systemd unit. The option `services.xserver.desktopManager.xfce.thunarPlugins` has been renamed to `programs.thunar.plugins`, and in a future release it may be removed.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/lib/qemu-common.nix
+++ b/nixos/lib/qemu-common.nix
@@ -5,7 +5,7 @@ let
   zeroPad = n:
     lib.optionalString (n < 16) "0" +
       (if n > 255
-       then throw "Can't have more than 255 nets or nodes!"
+       then throw "Can't have more than 255 nics or nodes!"
        else lib.toHexString n);
 in
 
@@ -13,7 +13,7 @@ rec {
   qemuNicMac = net: machine: "52:54:00:12:${zeroPad net}:${zeroPad machine}";
 
   qemuNICFlags = nic: net: machine:
-    [ "-device virtio-net-pci,netdev=vlan${toString nic},mac=${qemuNicMac net machine}"
+    [ "-device virtio-net-pci,netdev=vlan${toString nic},mac=${qemuNicMac nic machine}"
       ''-netdev vde,id=vlan${toString nic},sock="$QEMU_VDE_SOCKET_${toString net}"''
     ];
 

--- a/nixos/lib/testing/driver.nix
+++ b/nixos/lib/testing/driver.nix
@@ -12,7 +12,9 @@ let
   };
 
 
-  vlans = map (m: m.virtualisation.vlans) (lib.attrValues config.nodes);
+  vlans = map (m: (
+    m.virtualisation.vlans ++
+    (lib.mapAttrsToList (_: v: v.vlan) m.virtualisation.interfaces))) (lib.attrValues config.nodes);
   vms = map (m: m.system.build.vm) (lib.attrValues config.nodes);
 
   nodeHostNames =

--- a/nixos/lib/testing/network.nix
+++ b/nixos/lib/testing/network.nix
@@ -18,24 +18,40 @@ let
 
   networkModule = { config, nodes, pkgs, ... }:
     let
-      interfacesNumbered = zipLists config.virtualisation.vlans (range 1 255);
-      interfaces = forEach interfacesNumbered ({ fst, snd }:
-        nameValuePair "eth${toString snd}" {
-          ipv4.addresses =
-            [{
-              address = "192.168.${toString fst}.${toString config.virtualisation.test.nodeNumber}";
-              prefixLength = 24;
-            }];
-        });
+      # Convert legacy VLANs to named interfaces and merge with explicit interfaces.
+      vlansNumbered = forEach (zipLists config.virtualisation.vlans (range 1 255)) (v: {
+        name = "eth${toString v.snd}";
+        vlan = v.fst;
+        assignIP = true;
+      });
+      explicitInterfaces = lib.mapAttrsToList (n: v: v // { name = n; }) config.virtualisation.interfaces;
+      interfaces = vlansNumbered ++ explicitInterfaces;
+      interfacesNumbered = zipLists interfaces (range 1 255);
+      nodeNumber = config.virtualisation.test.nodeNumber;
+
+      # Automatically assign IP addresses to requested interfaces.
+      assignIPs = lib.filter (i: i.assignIP) interfaces;
+      ipInterfaces = forEach assignIPs (i:
+        nameValuePair i.name { ipv4.addresses =
+          [ { address = "192.168.${toString i.vlan}.${toString nodeNumber}";
+                prefixLength = 24;
+            } ];
+          });
+
+      qemu-common = import ../qemu-common.nix { inherit lib pkgs; };
+      qemuOptions = lib.flatten (forEach interfacesNumbered ({ fst, snd }:
+        qemu-common.qemuNICFlags snd fst.vlan nodeNumber));
+      udevRules = forEach interfacesNumbered ({ fst, snd }:
+        "SUBSYSTEM==\"net\",ACTION==\"add\",ATTR{address}==\"${qemu-common.qemuNicMac snd nodeNumber}\",NAME=\"${fst.name}\"");
 
       networkConfig =
         {
           networking.hostName = mkDefault config.virtualisation.test.nodeName;
 
-          networking.interfaces = listToAttrs interfaces;
+          networking.interfaces = listToAttrs ipInterfaces;
 
           networking.primaryIPAddress =
-            optionalString (interfaces != [ ]) (head (head interfaces).value.ipv4.addresses).address;
+            optionalString (ipInterfaces != []) (head (head ipInterfaces).value.ipv4.addresses).address;
 
           # Put the IP addresses of all VMs in this machine's
           # /etc/hosts file.  If a machine has multiple
@@ -51,16 +67,13 @@ let
                     "${config.networking.hostName}.${config.networking.domain} " +
                   "${config.networking.hostName}\n"));
 
-          virtualisation.qemu.options =
-            let qemu-common = import ../qemu-common.nix { inherit lib pkgs; };
-            in
-            flip concatMap interfacesNumbered
-              ({ fst, snd }: qemu-common.qemuNICFlags snd fst config.virtualisation.test.nodeNumber);
+          virtualisation.qemu.options = qemuOptions;
+          boot.initrd.services.udev.rules = concatMapStrings (x: x + "\n") udevRules;
         };
 
     in
     {
-      key = "ip-address";
+      key = "network-interfaces";
       config = networkConfig // {
         # Expose the networkConfig items for tests like nixops
         # that need to recreate the network config.

--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -511,7 +511,8 @@ in
     virtualisation.vlans =
       mkOption {
         type = types.listOf types.ints.unsigned;
-        default = [ 1 ];
+        default = if config.virtualisation.interfaces == {} then [ 1 ] else [ ];
+        defaultText = lib.literalExpression ''if config.virtualisation.interfaces == {} then [ 1 ] else [ ]'';
         example = [ 1 2 ];
         description =
           ''
@@ -525,6 +526,35 @@ in
             in the list of VMs.
           '';
       };
+ 
+    virtualisation.interfaces = mkOption {
+      default = {};
+      example = {
+        enp1s0.vlan = 1;
+      };
+      description = ''
+        Network interfaces to add to the VM.
+      '';
+      type = with types; attrsOf (submodule {
+        options = {
+          vlan = mkOption {
+            type = types.ints.unsigned;
+            description = ''
+              VLAN to which the network interface is connected.
+            '';
+          };
+
+          assignIP = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Automatically assign an IP address to the network interface using the same scheme as
+              virtualisation.vlans.
+            '';
+          };
+        };
+      });
+    };
 
     virtualisation.writableStore =
       mkOption {


### PR DESCRIPTION
Adds a new option to the virtualisation modules that enables specifying explicitly named network interfaces in QEMU VMs. The existing `virtualisation.vlans` is still supported for cases where the name of the network interface is irrelevant.

This feature is useful for creating VMs with network configurations that exactly match the network configuration of real-world devices for more accurate SITL testing.

###### Description of changes

- Added `virtualisation.interfaces` option to `qemu-vm.nix`.
- Updated the default value of `virtualisation.vlans` to empty if `virtualisation.interfaces` is not empty. This avoids a scenario where a user specifies `virtualisation.interfaces`, but inadvertently still has a network interface from the default `virtualisation.vlans`.
- Updated `build-vms.nix` to create the new network interfaces using QEMU options.
- Updated `build-vms.nix` to rename network interfaces using udev rules.
- Updated `testing-python.nix` to use the union of the VLANs specified in `virtualisation.vlans` and `virtualisation.interfaces` when collecting the list of VLANs.
- Updated networking tests in `nixos/tests/networking.nix` to use the new option where applicable. This cut down on unnecessary overrides to remove IP addresses from network interfaces.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [x] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
